### PR TITLE
MSSQL OTEL: Added MSSQL Failover cluster metrics for Azure Managed Instance.

### DIFF
--- a/receiver/newrelicsqlserverreceiver/config.go
+++ b/receiver/newrelicsqlserverreceiver/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	EnableFailoverClusterAvailabilityGroupHealthMetrics bool `mapstructure:"enable_failover_cluster_availability_group_health_metrics"`
 	EnableFailoverClusterAvailabilityGroupMetrics       bool `mapstructure:"enable_failover_cluster_availability_group_metrics"`
 	EnableFailoverClusterPerformanceCounterMetrics      bool `mapstructure:"enable_failover_cluster_performance_counter_metrics"`
-	EnableFailoverClusterClusterPropertiesMetrics       bool `mapstructure:"enable_failover_cluster_cluster_properties_metrics"`
+	EnableFailoverClusterRedoQueueMetrics               bool `mapstructure:"enable_failover_cluster_redo_queue_metrics"`
 
 	// Database security metrics configuration
 	EnableDatabasePrincipalsMetrics     bool `mapstructure:"enable_database_principals_metrics"`
@@ -132,7 +132,7 @@ func DefaultConfig() component.Config {
 		EnableFailoverClusterAvailabilityGroupHealthMetrics: false, // Availability Group health and role status
 		EnableFailoverClusterAvailabilityGroupMetrics:       false, // Availability Group configuration metrics
 		EnableFailoverClusterPerformanceCounterMetrics:      false, // Extended performance counters for Always On
-		EnableFailoverClusterClusterPropertiesMetrics:       false, // Cluster properties and quorum information
+		EnableFailoverClusterRedoQueueMetrics:               false, // Redo queue metrics (Azure SQL Managed Instance only)
 
 		// Database security metrics defaults
 		EnableDatabasePrincipalsMetrics:     false, // Database principals and users information
@@ -443,9 +443,10 @@ func (cfg *Config) IsFailoverClusterPerformanceCounterMetricsEnabled() bool {
 	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterPerformanceCounterMetrics
 }
 
-// IsFailoverClusterClusterPropertiesMetricsEnabled checks if cluster properties metrics should be collected
-func (cfg *Config) IsFailoverClusterClusterPropertiesMetricsEnabled() bool {
-	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterClusterPropertiesMetrics
+// IsFailoverClusterRedoQueueMetricsEnabled checks if failover cluster redo queue metrics should be collected
+// This is only applicable to Azure SQL Managed Instance
+func (cfg *Config) IsFailoverClusterRedoQueueMetricsEnabled() bool {
+	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterRedoQueueMetrics
 }
 
 // IsDatabasePrincipalsMetricsEnabled checks if database principals metrics should be collected

--- a/receiver/newrelicsqlserverreceiver/config.go
+++ b/receiver/newrelicsqlserverreceiver/config.go
@@ -45,10 +45,8 @@ type Config struct {
 	// Granular failover cluster metrics configuration
 	EnableFailoverClusterReplicaMetrics                 bool `mapstructure:"enable_failover_cluster_replica_metrics"`
 	EnableFailoverClusterReplicaStateMetrics            bool `mapstructure:"enable_failover_cluster_replica_state_metrics"`
-	EnableFailoverClusterNodeMetrics                    bool `mapstructure:"enable_failover_cluster_node_metrics"`
 	EnableFailoverClusterAvailabilityGroupHealthMetrics bool `mapstructure:"enable_failover_cluster_availability_group_health_metrics"`
 	EnableFailoverClusterAvailabilityGroupMetrics       bool `mapstructure:"enable_failover_cluster_availability_group_metrics"`
-	EnableFailoverClusterPerformanceCounterMetrics      bool `mapstructure:"enable_failover_cluster_performance_counter_metrics"`
 	EnableFailoverClusterRedoQueueMetrics               bool `mapstructure:"enable_failover_cluster_redo_queue_metrics"`
 
 	// Database security metrics configuration
@@ -128,10 +126,8 @@ func DefaultConfig() component.Config {
 		// Default granular failover cluster metrics (disabled by default)
 		EnableFailoverClusterReplicaMetrics:                 false, // Always On replica performance metrics
 		EnableFailoverClusterReplicaStateMetrics:            false, // Database replica state and synchronization metrics
-		EnableFailoverClusterNodeMetrics:                    false, // Windows Server Failover Cluster node metrics
 		EnableFailoverClusterAvailabilityGroupHealthMetrics: false, // Availability Group health and role status
 		EnableFailoverClusterAvailabilityGroupMetrics:       false, // Availability Group configuration metrics
-		EnableFailoverClusterPerformanceCounterMetrics:      false, // Extended performance counters for Always On
 		EnableFailoverClusterRedoQueueMetrics:               false, // Redo queue metrics (Azure SQL Managed Instance only)
 
 		// Database security metrics defaults
@@ -423,11 +419,6 @@ func (cfg *Config) IsFailoverClusterReplicaStateMetricsEnabled() bool {
 	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterReplicaStateMetrics
 }
 
-// IsFailoverClusterNodeMetricsEnabled checks if failover cluster node metrics should be collected
-func (cfg *Config) IsFailoverClusterNodeMetricsEnabled() bool {
-	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterNodeMetrics
-}
-
 // IsFailoverClusterAvailabilityGroupHealthMetricsEnabled checks if availability group health metrics should be collected
 func (cfg *Config) IsFailoverClusterAvailabilityGroupHealthMetricsEnabled() bool {
 	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterAvailabilityGroupHealthMetrics
@@ -436,11 +427,6 @@ func (cfg *Config) IsFailoverClusterAvailabilityGroupHealthMetricsEnabled() bool
 // IsFailoverClusterAvailabilityGroupMetricsEnabled checks if availability group configuration metrics should be collected
 func (cfg *Config) IsFailoverClusterAvailabilityGroupMetricsEnabled() bool {
 	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterAvailabilityGroupMetrics
-}
-
-// IsFailoverClusterPerformanceCounterMetricsEnabled checks if failover cluster performance counter metrics should be collected
-func (cfg *Config) IsFailoverClusterPerformanceCounterMetricsEnabled() bool {
-	return cfg.EnableFailoverClusterMetrics || cfg.EnableFailoverClusterPerformanceCounterMetrics
 }
 
 // IsFailoverClusterRedoQueueMetricsEnabled checks if failover cluster redo queue metrics should be collected

--- a/receiver/newrelicsqlserverreceiver/granular_toggles_test.go
+++ b/receiver/newrelicsqlserverreceiver/granular_toggles_test.go
@@ -25,7 +25,7 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           false,
 				"ag_config":           false,
 				"performance_counter": false,
-				"cluster_properties":  false,
+				"redo_queue":          false,
 			},
 			expectedResults: map[string]bool{
 				"replica":             true, // main toggle overrides
@@ -34,7 +34,7 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           true, // main toggle overrides
 				"ag_config":           true, // main toggle overrides
 				"performance_counter": true, // main toggle overrides
-				"cluster_properties":  true, // main toggle overrides
+				"redo_queue":          true, // main toggle overrides
 			},
 			description: "When main toggle is enabled, all granular metrics are enabled regardless of individual settings",
 		},
@@ -48,7 +48,7 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           true,
 				"ag_config":           false,
 				"performance_counter": false,
-				"cluster_properties":  true,
+				"redo_queue":          true,
 			},
 			expectedResults: map[string]bool{
 				"replica":             true,
@@ -57,7 +57,7 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           true,
 				"ag_config":           false,
 				"performance_counter": false,
-				"cluster_properties":  true,
+				"redo_queue":          true,
 			},
 			description: "When main toggle is disabled, individual toggles control their respective metrics",
 		},
@@ -71,7 +71,6 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           false,
 				"ag_config":           false,
 				"performance_counter": false,
-				"cluster_properties":  false,
 			},
 			expectedResults: map[string]bool{
 				"replica":             false,
@@ -80,7 +79,6 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				"ag_health":           false,
 				"ag_config":           false,
 				"performance_counter": false,
-				"cluster_properties":  false,
 			},
 			description: "When all toggles are disabled, no metrics are enabled",
 		},
@@ -119,7 +117,7 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				EnableFailoverClusterAvailabilityGroupHealthMetrics: tt.granularToggles["ag_health"],
 				EnableFailoverClusterAvailabilityGroupMetrics:       tt.granularToggles["ag_config"],
 				EnableFailoverClusterPerformanceCounterMetrics:      tt.granularToggles["performance_counter"],
-				EnableFailoverClusterClusterPropertiesMetrics:       tt.granularToggles["cluster_properties"],
+				EnableFailoverClusterRedoQueueMetrics:               tt.granularToggles["redo_queue"],
 			}
 
 			// Test all granular helper methods
@@ -141,8 +139,11 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 			assert.Equal(t, tt.expectedResults["performance_counter"], config.IsFailoverClusterPerformanceCounterMetricsEnabled(),
 				"Performance counter metrics enabled check failed for test: %s", tt.description)
 
-			assert.Equal(t, tt.expectedResults["cluster_properties"], config.IsFailoverClusterClusterPropertiesMetricsEnabled(),
-				"Cluster properties metrics enabled check failed for test: %s", tt.description)
+			// Add redo queue metrics test (only for Azure SQL Managed Instance)
+			if redoQueueExpected, exists := tt.expectedResults["redo_queue"]; exists {
+				assert.Equal(t, redoQueueExpected, config.IsFailoverClusterRedoQueueMetricsEnabled(),
+					"Redo queue metrics enabled check failed for test: %s", tt.description)
+			}
 		})
 	}
 }
@@ -161,7 +162,7 @@ func TestGranularToggleDefaults(t *testing.T) {
 	assert.False(t, config.EnableFailoverClusterAvailabilityGroupHealthMetrics, "AG health metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterAvailabilityGroupMetrics, "AG config metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterPerformanceCounterMetrics, "Performance counter metrics toggle should default to false")
-	assert.False(t, config.EnableFailoverClusterClusterPropertiesMetrics, "Cluster properties metrics toggle should default to false")
+	assert.False(t, config.EnableFailoverClusterRedoQueueMetrics, "Redo queue metrics toggle should default to false")
 
 	// With all defaults (false), helper methods should return false
 	assert.False(t, config.IsFailoverClusterReplicaMetricsEnabled(), "Replica metrics should be disabled by default")
@@ -170,7 +171,7 @@ func TestGranularToggleDefaults(t *testing.T) {
 	assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled(), "AG health metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled(), "AG config metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled(), "Performance counter metrics should be disabled by default")
-	assert.False(t, config.IsFailoverClusterClusterPropertiesMetricsEnabled(), "Cluster properties metrics should be disabled by default")
+	assert.False(t, config.IsFailoverClusterRedoQueueMetricsEnabled(), "Redo queue metrics should be disabled by default")
 }
 
 // TestLogicalORBehavior specifically tests the logical OR behavior of toggles
@@ -435,7 +436,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
-		assert.True(t, config.IsFailoverClusterClusterPropertiesMetricsEnabled())
 	})
 
 	t.Run("production_critical_only", func(t *testing.T) {
@@ -447,7 +447,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 			EnableFailoverClusterAvailabilityGroupMetrics:       true,  // Important
 			EnableFailoverClusterNodeMetrics:                    true,  // Important
 			EnableFailoverClusterPerformanceCounterMetrics:      false, // Optional
-			EnableFailoverClusterClusterPropertiesMetrics:       false, // Optional
 		}
 
 		// Critical metrics enabled
@@ -459,7 +458,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 
 		// Optional metrics disabled
 		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterClusterPropertiesMetricsEnabled())
 	})
 
 	t.Run("development_lightweight", func(t *testing.T) {
@@ -474,7 +472,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterClusterPropertiesMetricsEnabled())
 	})
 
 	t.Run("single_metric_debugging", func(t *testing.T) {
@@ -492,6 +489,5 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterClusterPropertiesMetricsEnabled())
 	})
 }

--- a/receiver/newrelicsqlserverreceiver/granular_toggles_test.go
+++ b/receiver/newrelicsqlserverreceiver/granular_toggles_test.go
@@ -113,10 +113,8 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 				EnableFailoverClusterMetrics:                        tt.mainToggle,
 				EnableFailoverClusterReplicaMetrics:                 tt.granularToggles["replica"],
 				EnableFailoverClusterReplicaStateMetrics:            tt.granularToggles["replica_state"],
-				EnableFailoverClusterNodeMetrics:                    tt.granularToggles["node"],
 				EnableFailoverClusterAvailabilityGroupHealthMetrics: tt.granularToggles["ag_health"],
 				EnableFailoverClusterAvailabilityGroupMetrics:       tt.granularToggles["ag_config"],
-				EnableFailoverClusterPerformanceCounterMetrics:      tt.granularToggles["performance_counter"],
 				EnableFailoverClusterRedoQueueMetrics:               tt.granularToggles["redo_queue"],
 			}
 
@@ -127,17 +125,11 @@ func TestGranularFailoverClusterToggles(t *testing.T) {
 			assert.Equal(t, tt.expectedResults["replica_state"], config.IsFailoverClusterReplicaStateMetricsEnabled(),
 				"Replica state metrics enabled check failed for test: %s", tt.description)
 
-			assert.Equal(t, tt.expectedResults["node"], config.IsFailoverClusterNodeMetricsEnabled(),
-				"Node metrics enabled check failed for test: %s", tt.description)
-
 			assert.Equal(t, tt.expectedResults["ag_health"], config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled(),
 				"AG health metrics enabled check failed for test: %s", tt.description)
 
 			assert.Equal(t, tt.expectedResults["ag_config"], config.IsFailoverClusterAvailabilityGroupMetricsEnabled(),
 				"AG config metrics enabled check failed for test: %s", tt.description)
-
-			assert.Equal(t, tt.expectedResults["performance_counter"], config.IsFailoverClusterPerformanceCounterMetricsEnabled(),
-				"Performance counter metrics enabled check failed for test: %s", tt.description)
 
 			// Add redo queue metrics test (only for Azure SQL Managed Instance)
 			if redoQueueExpected, exists := tt.expectedResults["redo_queue"]; exists {
@@ -158,19 +150,15 @@ func TestGranularToggleDefaults(t *testing.T) {
 	// All granular toggles should default to false
 	assert.False(t, config.EnableFailoverClusterReplicaMetrics, "Replica metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterReplicaStateMetrics, "Replica state metrics toggle should default to false")
-	assert.False(t, config.EnableFailoverClusterNodeMetrics, "Node metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterAvailabilityGroupHealthMetrics, "AG health metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterAvailabilityGroupMetrics, "AG config metrics toggle should default to false")
-	assert.False(t, config.EnableFailoverClusterPerformanceCounterMetrics, "Performance counter metrics toggle should default to false")
 	assert.False(t, config.EnableFailoverClusterRedoQueueMetrics, "Redo queue metrics toggle should default to false")
 
 	// With all defaults (false), helper methods should return false
 	assert.False(t, config.IsFailoverClusterReplicaMetricsEnabled(), "Replica metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterReplicaStateMetricsEnabled(), "Replica state metrics should be disabled by default")
-	assert.False(t, config.IsFailoverClusterNodeMetricsEnabled(), "Node metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled(), "AG health metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled(), "AG config metrics should be disabled by default")
-	assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled(), "Performance counter metrics should be disabled by default")
 	assert.False(t, config.IsFailoverClusterRedoQueueMetricsEnabled(), "Redo queue metrics should be disabled by default")
 }
 
@@ -432,10 +420,8 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		// All metrics should be enabled when main toggle is true
 		assert.True(t, config.IsFailoverClusterReplicaMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterReplicaStateMetricsEnabled())
-		assert.True(t, config.IsFailoverClusterNodeMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
-		assert.True(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
 	})
 
 	t.Run("production_critical_only", func(t *testing.T) {
@@ -445,8 +431,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 			EnableFailoverClusterReplicaStateMetrics:            true,  // Critical
 			EnableFailoverClusterAvailabilityGroupHealthMetrics: true,  // Critical
 			EnableFailoverClusterAvailabilityGroupMetrics:       true,  // Important
-			EnableFailoverClusterNodeMetrics:                    true,  // Important
-			EnableFailoverClusterPerformanceCounterMetrics:      false, // Optional
 		}
 
 		// Critical metrics enabled
@@ -454,10 +438,6 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		assert.True(t, config.IsFailoverClusterReplicaStateMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.True(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
-		assert.True(t, config.IsFailoverClusterNodeMetricsEnabled())
-
-		// Optional metrics disabled
-		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
 	})
 
 	t.Run("development_lightweight", func(t *testing.T) {
@@ -468,10 +448,8 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 		// All metrics should be disabled for lightweight development monitoring
 		assert.False(t, config.IsFailoverClusterReplicaMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterReplicaStateMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterNodeMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
 	})
 
 	t.Run("single_metric_debugging", func(t *testing.T) {
@@ -485,9 +463,7 @@ func TestProductionUseCaseScenarios(t *testing.T) {
 
 		// All others disabled
 		assert.False(t, config.IsFailoverClusterReplicaStateMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterNodeMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled())
 		assert.False(t, config.IsFailoverClusterAvailabilityGroupMetricsEnabled())
-		assert.False(t, config.IsFailoverClusterPerformanceCounterMetricsEnabled())
 	})
 }

--- a/receiver/newrelicsqlserverreceiver/models/failover_cluster_metrics.go
+++ b/receiver/newrelicsqlserverreceiver/models/failover_cluster_metrics.go
@@ -138,24 +138,6 @@ type FailoverClusterReplicaStateMetrics struct {
 	SuspendReasonDesc *string `db:"suspend_reason_desc" metric_name:"sqlserver.failover_cluster.suspend_reason" source_type:"info"`
 }
 
-// FailoverClusterNodeMetrics represents cluster node information and status
-// This model captures the server node details in a Windows Server Failover Cluster
-type FailoverClusterNodeMetrics struct {
-	// NodeName represents the name of the server node in the cluster
-	// Query source: sys.dm_os_cluster_nodes.nodename
-	NodeName string `db:"nodename" source_type:"attribute"`
-
-	// StatusDescription represents the health state of the cluster node
-	// Query source: sys.dm_os_cluster_nodes.status_description
-	// Expected values: "Up", "Down", "Paused", etc.
-	StatusDescription string `db:"status_description" metric_name:"sqlserver.failover_cluster.node_status" source_type:"info"`
-
-	// IsCurrentOwner indicates if this is the active node currently running the SQL Server instance
-	// Query source: sys.dm_os_cluster_nodes.is_current_owner
-	// Value: 1 = active node, 0 = passive node
-	IsCurrentOwner *int64 `db:"is_current_owner" metric_name:"sqlserver.failover_cluster.node_is_current_owner" source_type:"gauge"`
-}
-
 // FailoverClusterAvailabilityGroupHealthMetrics represents Always On Availability Group health status
 // This model captures the health and role information for availability group replicas
 type FailoverClusterAvailabilityGroupHealthMetrics struct {
@@ -245,29 +227,9 @@ type FailoverClusterAvailabilityGroupMetrics struct {
 	RequiredSynchronizedSecondariesToCommit *int64 `db:"required_synchronized_secondaries_to_commit" metric_name:"sqlserver.failover_cluster.required_sync_secondaries" source_type:"gauge"`
 }
 
-// FailoverClusterPerformanceCounterMetrics represents core Always On performance counter metrics
-// This model captures essential performance counters for monitoring replica performance using a PIVOT structure
-// Simplified to focus on the 3 most critical performance indicators for consistency with replica metrics
-type FailoverClusterPerformanceCounterMetrics struct {
-	// InstanceName represents the instance name for the performance counter (database name or _Total)
-	// Query source: sys.dm_os_performance_counters.instance_name
-	InstanceName string `db:"instance_name" source_type:"attribute"`
-
-	// LogBytesReceivedSec represents the rate of log records received by secondary replica from primary replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Log Bytes Received/sec'
-	LogBytesReceivedSec *int64 `db:"Log Bytes Received/sec" metric_name:"sqlserver.failover_cluster.log_bytes_received_per_sec" source_type:"gauge"`
-
-	// TransactionDelay represents the average delay for transactions on the secondary replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Transaction Delay'
-	TransactionDelay *int64 `db:"Transaction Delay" metric_name:"sqlserver.failover_cluster.transaction_delay_ms" source_type:"gauge"`
-
-	// FlowControlTimeMs represents time spent in flow control by log records from primary replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Flow Control Time (ms/sec)'
-	FlowControlTimeMs *int64 `db:"Flow Control Time (ms/sec)" metric_name:"sqlserver.failover_cluster.flow_control_time_ms" source_type:"gauge"`
-}
-
-// FailoverClusterRedoQueueMetrics represents Always On redo queue metrics specific to Azure SQL Managed Instance
+// FailoverClusterRedoQueueMetrics represents Always On redo queue metrics
 // This model captures log send queue, redo queue, and redo rate metrics for monitoring replication performance
+// Compatible with both Standard SQL Server and Azure SQL Managed Instance
 type FailoverClusterRedoQueueMetrics struct {
 	// ReplicaServerName represents the name of the server hosting the replica
 	// Query source: sys.availability_replicas.replica_server_name joined with sys.dm_hadr_database_replica_states

--- a/receiver/newrelicsqlserverreceiver/models/failover_cluster_metrics.go
+++ b/receiver/newrelicsqlserverreceiver/models/failover_cluster_metrics.go
@@ -48,6 +48,10 @@ package models
 // FailoverClusterReplicaMetrics represents Always On Availability Group replica performance metrics
 // This model captures the replica-level performance data as defined for Always On failover clusters
 type FailoverClusterReplicaMetrics struct {
+	// InstanceName represents the database instance name from performance counters
+	// Query source: sys.dm_os_performance_counters.instance_name for Database Replica counters
+	InstanceName string `db:"instance_name" source_type:"attribute"`
+
 	// LogBytesReceivedPerSec represents the rate of log records received by secondary replica from primary
 	// This metric corresponds to 'Log Bytes Received/sec' performance counter
 	// Query source: sys.dm_os_performance_counters for Database Replica counters
@@ -65,7 +69,7 @@ type FailoverClusterReplicaMetrics struct {
 }
 
 // FailoverClusterReplicaStateMetrics represents Always On Availability Group database replica state metrics
-// This model captures the database-level replica state information including log synchronization details
+// This model captures the essential database-level replica state information including log synchronization details
 type FailoverClusterReplicaStateMetrics struct {
 	// ReplicaServerName represents the name of the server hosting the replica
 	// Query source: sys.availability_replicas joined with sys.dm_hadr_database_replica_states
@@ -92,47 +96,45 @@ type FailoverClusterReplicaStateMetrics struct {
 
 	// DatabaseStateDesc represents the current state of the database replica
 	// Query source: sys.dm_hadr_database_replica_states.database_state_desc
-	// Expected values: "ONLINE", "RESTORING", "RECOVERING", "RECOVERY_PENDING", "SUSPECT", etc.
-	// Can be NULL if not applicable
-	DatabaseStateDesc *string `db:"database_state_desc" metric_name:"sqlserver.failover_cluster.database_state" source_type:"info"`
+	// Expected values: "ONLINE", "RESTORING", "RECOVERING", "RECOVERY_PENDING", "SUSPECT", "EMERGENCY", "OFFLINE"
+	DatabaseStateDesc string `db:"database_state_desc" metric_name:"sqlserver.failover_cluster.database_state" source_type:"info"`
 
 	// SynchronizationStateDesc represents the synchronization state of the database replica
 	// Query source: sys.dm_hadr_database_replica_states.synchronization_state_desc
-	// Expected values: "SYNCHRONIZED", "SYNCHRONIZING", "NOT_SYNCHRONIZING", "INITIALIZING", "REVERTING"
-	// Can be NULL if not applicable
-	SynchronizationStateDesc *string `db:"synchronization_state_desc" metric_name:"sqlserver.failover_cluster.synchronization_state" source_type:"info"`
+	// Expected values: "SYNCHRONIZING", "SYNCHRONIZED", "NOT SYNCHRONIZING", "REVERTING", "INITIALIZING"
+	SynchronizationStateDesc string `db:"synchronization_state_desc" metric_name:"sqlserver.failover_cluster.synchronization_state" source_type:"info"`
 
-	// IsLocal indicates if this is a local replica (1) or remote replica (0)
+	// IsLocal indicates whether this is a local replica (1) or remote (0)
 	// Query source: sys.dm_hadr_database_replica_states.is_local
 	IsLocal *int64 `db:"is_local" metric_name:"sqlserver.failover_cluster.is_local_replica" source_type:"gauge"`
 
-	// IsPrimaryReplica indicates if this is the primary replica (1) or secondary (0)
+	// IsPrimaryReplica indicates whether this is the primary replica (1) or secondary (0)
 	// Query source: sys.dm_hadr_database_replica_states.is_primary_replica
 	IsPrimaryReplica *int64 `db:"is_primary_replica" metric_name:"sqlserver.failover_cluster.is_primary_replica" source_type:"gauge"`
 
 	// LastCommitTime represents the timestamp of the last transaction commit
 	// Query source: sys.dm_hadr_database_replica_states.last_commit_time
-	LastCommitTime *string `db:"last_commit_time" source_type:"attribute"`
+	LastCommitTime *string `db:"last_commit_time" metric_name:"sqlserver.failover_cluster.last_commit_time" source_type:"info"`
 
 	// LastSentTime represents the timestamp when the last log block was sent
 	// Query source: sys.dm_hadr_database_replica_states.last_sent_time
-	LastSentTime *string `db:"last_sent_time" source_type:"attribute"`
+	LastSentTime *string `db:"last_sent_time" metric_name:"sqlserver.failover_cluster.last_sent_time" source_type:"info"`
 
 	// LastReceivedTime represents the timestamp when the last log block was received
 	// Query source: sys.dm_hadr_database_replica_states.last_received_time
-	LastReceivedTime *string `db:"last_received_time" source_type:"attribute"`
+	LastReceivedTime *string `db:"last_received_time" metric_name:"sqlserver.failover_cluster.last_received_time" source_type:"info"`
 
 	// LastHardenedTime represents the timestamp when the last log block was hardened
 	// Query source: sys.dm_hadr_database_replica_states.last_hardened_time
-	LastHardenedTime *string `db:"last_hardened_time" source_type:"attribute"`
+	LastHardenedTime *string `db:"last_hardened_time" metric_name:"sqlserver.failover_cluster.last_hardened_time" source_type:"info"`
 
 	// LastRedoneLSN represents the log sequence number of the last redone log record
 	// Query source: sys.dm_hadr_database_replica_states.last_redone_lsn
-	LastRedoneLSN *string `db:"last_redone_lsn" source_type:"attribute"`
+	LastRedoneLSN *string `db:"last_redone_lsn" metric_name:"sqlserver.failover_cluster.last_redone_lsn" source_type:"info"`
 
 	// SuspendReasonDesc represents the reason why the database is suspended (if applicable)
 	// Query source: sys.dm_hadr_database_replica_states.suspend_reason_desc
-	// Expected values: NULL, "SUSPEND", "REDO", "APPLY", "CAPTURE", "RESTART", "UNDO", "REVALIDATE", "OTHER"
+	// Expected values: null (not suspended), or reason descriptions like "SUSPEND_FROM_USER", etc.
 	SuspendReasonDesc *string `db:"suspend_reason_desc" metric_name:"sqlserver.failover_cluster.suspend_reason" source_type:"info"`
 }
 
@@ -243,63 +245,47 @@ type FailoverClusterAvailabilityGroupMetrics struct {
 	RequiredSynchronizedSecondariesToCommit *int64 `db:"required_synchronized_secondaries_to_commit" metric_name:"sqlserver.failover_cluster.required_sync_secondaries" source_type:"gauge"`
 }
 
-// FailoverClusterPerformanceCounterMetrics represents additional Always On performance counter metrics
-// This model captures extended performance counters for comprehensive monitoring using a PIVOT structure
-// Each performance counter is represented as a separate column for easier consumption in monitoring systems
+// FailoverClusterPerformanceCounterMetrics represents core Always On performance counter metrics
+// This model captures essential performance counters for monitoring replica performance using a PIVOT structure
+// Simplified to focus on the 3 most critical performance indicators for consistency with replica metrics
 type FailoverClusterPerformanceCounterMetrics struct {
 	// InstanceName represents the instance name for the performance counter (database name or _Total)
 	// Query source: sys.dm_os_performance_counters.instance_name
 	InstanceName string `db:"instance_name" source_type:"attribute"`
 
-	// LogSendRateKBSec represents the rate at which log records are sent to secondary replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Log Send Rate (KB/sec)'
-	LogSendRateKBSec *int64 `db:"Log Send Rate (KB/sec)" metric_name:"sqlserver.failover_cluster.log_send_rate_kb_sec" source_type:"gauge"`
+	// LogBytesReceivedSec represents the rate of log records received by secondary replica from primary replica
+	// Query source: sys.dm_os_performance_counters where counter_name = 'Log Bytes Received/sec'
+	LogBytesReceivedSec *int64 `db:"Log Bytes Received/sec" metric_name:"sqlserver.failover_cluster.log_bytes_received_per_sec" source_type:"gauge"`
 
-	// RecoveryQueue represents the number of log records waiting to be recovered
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Recovery Queue'
-	RecoveryQueue *int64 `db:"Recovery Queue" metric_name:"sqlserver.failover_cluster.recovery_queue" source_type:"gauge"`
+	// TransactionDelay represents the average delay for transactions on the secondary replica
+	// Query source: sys.dm_os_performance_counters where counter_name = 'Transaction Delay'
+	TransactionDelay *int64 `db:"Transaction Delay" metric_name:"sqlserver.failover_cluster.transaction_delay_ms" source_type:"gauge"`
 
-	// FileBytesReceivedSec represents the rate of file bytes received per second
-	// Query source: sys.dm_os_performance_counters where counter_name = 'File Bytes Received/sec'
-	FileBytesReceivedSec *int64 `db:"File Bytes Received/sec" metric_name:"sqlserver.failover_cluster.file_bytes_received_sec" source_type:"gauge"`
-
-	// MirroredWriteTransactionsSec represents the rate of mirrored write transactions
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Mirrored Write Transactions/sec'
-	MirroredWriteTransactionsSec *int64 `db:"Mirrored Write Transactions/sec" metric_name:"sqlserver.failover_cluster.mirrored_write_transactions_sec" source_type:"gauge"`
-
-	// LogBytesFlushedSec represents the rate of log bytes flushed per second
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Log Bytes Flushed/sec'
-	LogBytesFlushedSec *int64 `db:"Log Bytes Flushed/sec" metric_name:"sqlserver.failover_cluster.log_bytes_flushed_sec" source_type:"gauge"`
-
-	// BytesSentToReplicaSec represents the rate of bytes sent to replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Bytes Sent to Replica/sec'
-	BytesSentToReplicaSec *int64 `db:"Bytes Sent to Replica/sec" metric_name:"sqlserver.failover_cluster.bytes_sent_to_replica_sec" source_type:"gauge"`
-
-	// BytesReceivedFromReplicaSec represents the rate of bytes received from replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Bytes Received from Replica/sec'
-	BytesReceivedFromReplicaSec *int64 `db:"Bytes Received from Replica/sec" metric_name:"sqlserver.failover_cluster.bytes_received_from_replica_sec" source_type:"gauge"`
-
-	// SendsToReplicaSec represents the rate of sends to replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Sends to Replica/sec'
-	SendsToReplicaSec *int64 `db:"Sends to Replica/sec" metric_name:"sqlserver.failover_cluster.sends_to_replica_sec" source_type:"gauge"`
-
-	// ReceivesFromReplicaSec represents the rate of receives from replica
-	// Query source: sys.dm_os_performance_counters where counter_name = 'Receives from Replica/sec'
-	ReceivesFromReplicaSec *int64 `db:"Receives from Replica/sec" metric_name:"sqlserver.failover_cluster.receives_from_replica_sec" source_type:"gauge"`
+	// FlowControlTimeMs represents time spent in flow control by log records from primary replica
+	// Query source: sys.dm_os_performance_counters where counter_name = 'Flow Control Time (ms/sec)'
+	FlowControlTimeMs *int64 `db:"Flow Control Time (ms/sec)" metric_name:"sqlserver.failover_cluster.flow_control_time_ms" source_type:"gauge"`
 }
 
-// FailoverClusterClusterPropertiesMetrics represents Windows cluster properties and quorum information
-// This model captures cluster-level configuration and health information
-type FailoverClusterClusterPropertiesMetrics struct {
-	// ClusterName represents the name of the Windows Server Failover Cluster
-	// Query source: sys.dm_os_cluster_properties where property_name = 'cluster_name'
-	ClusterName *string `db:"cluster_name" source_type:"attribute"`
+// FailoverClusterRedoQueueMetrics represents Always On redo queue metrics specific to Azure SQL Managed Instance
+// This model captures log send queue, redo queue, and redo rate metrics for monitoring replication performance
+type FailoverClusterRedoQueueMetrics struct {
+	// ReplicaServerName represents the name of the server hosting the replica
+	// Query source: sys.availability_replicas.replica_server_name joined with sys.dm_hadr_database_replica_states
+	ReplicaServerName string `db:"replica_server_name" source_type:"attribute"`
 
-	// QuorumType represents the quorum configuration type
-	// Query source: sys.dm_os_cluster_properties where property_name = 'quorum_type'
-	QuorumType *string `db:"quorum_type" metric_name:"sqlserver.failover_cluster.quorum_type" source_type:"info"`
+	// DatabaseName represents the name of the database in the availability group
+	// Query source: sys.databases.name joined with sys.dm_hadr_database_replica_states
+	DatabaseName string `db:"database_name" source_type:"attribute"`
 
-	// QuorumState represents the current quorum state
-	// Query source: sys.dm_os_cluster_properties where property_name = 'quorum_state'
-	QuorumState *string `db:"quorum_state" metric_name:"sqlserver.failover_cluster.quorum_state" source_type:"info"`
+	// LogSendQueueKB represents the amount of log records not yet sent to secondary replica (KB)
+	// Query source: sys.dm_hadr_database_replica_states.log_send_queue_size
+	LogSendQueueKB *int64 `db:"log_send_queue_kb" metric_name:"sqlserver.failover_cluster.log_send_queue_kb" source_type:"gauge"`
+
+	// RedoQueueKB represents the amount of log records waiting to be redone on secondary replica (KB)
+	// Query source: sys.dm_hadr_database_replica_states.redo_queue_size
+	RedoQueueKB *int64 `db:"redo_queue_kb" metric_name:"sqlserver.failover_cluster.redo_queue_kb" source_type:"gauge"`
+
+	// RedoRateKBSec represents the rate at which log records are being redone on secondary replica (KB/sec)
+	// Query source: sys.dm_hadr_database_replica_states.redo_rate
+	RedoRateKBSec *int64 `db:"redo_rate_kb_sec" metric_name:"sqlserver.failover_cluster.redo_rate_kb_sec" source_type:"gauge"`
 }

--- a/receiver/newrelicsqlserverreceiver/queries/engine_selector.go
+++ b/receiver/newrelicsqlserverreceiver/queries/engine_selector.go
@@ -560,73 +560,21 @@ var failoverClusterQueriesDefault = []*QueryDefinition{
 		MetricName:  "sqlserver.failover_cluster.performance_counter_metrics",
 		Description: "Always On Availability Group performance counter metrics",
 	},
-	{
-		Query:       FailoverClusterClusterPropertiesQuery,
-		MetricName:  "sqlserver.failover_cluster.cluster_properties_metrics",
-		Description: "Windows Server Failover Cluster properties and quorum information",
-	},
 }
 
 // Failover cluster query definitions for Azure SQL Database
+// Azure SQL Database does not support Always On Availability Groups (single database model)
+// Therefore no failover cluster metrics are applicable
 var failoverClusterQueriesAzureManagedDatabase = []*QueryDefinition{
-	{
-		Query:       FailoverClusterReplicaQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.replica_metrics",
-		Description: "Always On Availability Group replica metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterReplicaStateQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.replica_state_metrics",
-		Description: "Always On Availability Group replica state metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterNodeQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.node_metrics",
-		Description: "Cluster node metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterAvailabilityGroupHealthQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.availability_group_health_metrics",
-		Description: "Availability Group health metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterAvailabilityGroupQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.availability_group_metrics",
-		Description: "Availability Group configuration metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterPerformanceCounterQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.performance_counter_metrics",
-		Description: "Performance counter metrics (not applicable for Azure SQL Database)",
-	},
-	{
-		Query:       FailoverClusterClusterPropertiesQueryAzureSQL,
-		MetricName:  "sqlserver.failover_cluster.cluster_properties_metrics",
-		Description: "Cluster properties metrics (not applicable for Azure SQL Database)",
-	},
+	// Empty array - no failover cluster support in Azure SQL Database
 }
 
 // Failover cluster query definitions for Azure SQL Managed Instance
 var failoverClusterQueriesAzureManagedInstance = []*QueryDefinition{
 	{
-		Query:       FailoverClusterReplicaQueryAzureMI,
+		Query:       FailoverClusterReplicaQuery,
 		MetricName:  "sqlserver.failover_cluster.replica_metrics",
-		Description: "Always On Availability Group replica metrics (limited support for Azure SQL Managed Instance)",
-	},
-	{
-		Query:       FailoverClusterReplicaStateQueryAzureMI,
-		MetricName:  "sqlserver.failover_cluster.replica_state_metrics",
-		Description: "Always On Availability Group replica state metrics (Azure SQL Managed Instance)",
-	},
-	{
-		Query:       FailoverClusterNodeQueryAzureMI,
-		MetricName:  "sqlserver.failover_cluster.node_metrics",
-		Description: "Cluster node metrics (limited support for Azure SQL Managed Instance)",
-	},
-	{
-		Query:       FailoverClusterAvailabilityGroupHealthQueryAzureMI,
-		MetricName:  "sqlserver.failover_cluster.availability_group_health_metrics",
-		Description: "Availability Group health metrics (Azure SQL Managed Instance)",
+		Description: "Always On Availability Group replica performance metrics (Azure SQL Managed Instance)",
 	},
 	{
 		Query:       FailoverClusterAvailabilityGroupQueryAzureMI,
@@ -634,14 +582,14 @@ var failoverClusterQueriesAzureManagedInstance = []*QueryDefinition{
 		Description: "Availability Group configuration metrics (Azure SQL Managed Instance)",
 	},
 	{
-		Query:       FailoverClusterPerformanceCounterQueryAzureMI,
+		Query:       FailoverClusterPerformanceCounterQuery,
 		MetricName:  "sqlserver.failover_cluster.performance_counter_metrics",
-		Description: "Performance counter metrics (Azure SQL Managed Instance)",
+		Description: "Always On Availability Group core performance counter metrics (Azure SQL Managed Instance - simplified 3 metrics)",
 	},
 	{
-		Query:       FailoverClusterClusterPropertiesQueryAzureMI,
-		MetricName:  "sqlserver.failover_cluster.cluster_properties_metrics",
-		Description: "Cluster properties metrics (limited support for Azure SQL Managed Instance)",
+		Query:       FailoverClusterRedoQueueQueryAzureMI,
+		MetricName:  "sqlserver.failover_cluster.redo_queue_metrics",
+		Description: "Always On Availability Group redo queue metrics (Azure SQL Managed Instance only)",
 	},
 }
 

--- a/receiver/newrelicsqlserverreceiver/queries/engine_selector.go
+++ b/receiver/newrelicsqlserverreceiver/queries/engine_selector.go
@@ -9,6 +9,7 @@
 //
 //	type EngineSet[T any] struct {
 //	    Default                 T  // Standard SQL Server queries
+//	    AzureSQLDatabase        T  // Azure SQL //	    Default                 T  // Standard SQL Server queries
 //	    AzureSQLDatabase        T  // Azure SQL Database specific queries
 //	    AzureSQLManagedInstance T  // Azure SQL Managed Instance specific queries
 //	}
@@ -540,11 +541,7 @@ var failoverClusterQueriesDefault = []*QueryDefinition{
 		MetricName:  "sqlserver.failover_cluster.replica_state_metrics",
 		Description: "Always On Availability Group database replica state metrics",
 	},
-	{
-		Query:       FailoverClusterNodeQuery,
-		MetricName:  "sqlserver.failover_cluster.node_metrics",
-		Description: "Windows Server Failover Cluster node information and status",
-	},
+
 	{
 		Query:       FailoverClusterAvailabilityGroupHealthQuery,
 		MetricName:  "sqlserver.failover_cluster.availability_group_health_metrics",
@@ -556,9 +553,9 @@ var failoverClusterQueriesDefault = []*QueryDefinition{
 		Description: "Always On Availability Group configuration metrics",
 	},
 	{
-		Query:       FailoverClusterPerformanceCounterQuery,
-		MetricName:  "sqlserver.failover_cluster.performance_counter_metrics",
-		Description: "Always On Availability Group performance counter metrics",
+		Query:       FailoverClusterRedoQueueQuery,
+		MetricName:  "sqlserver.failover_cluster.redo_queue_metrics",
+		Description: "Always On Availability Group redo queue metrics",
 	},
 }
 
@@ -574,22 +571,32 @@ var failoverClusterQueriesAzureManagedInstance = []*QueryDefinition{
 	{
 		Query:       FailoverClusterReplicaQuery,
 		MetricName:  "sqlserver.failover_cluster.replica_metrics",
-		Description: "Always On Availability Group replica performance metrics (Azure SQL Managed Instance)",
+		Description: "Always On Availability Group replica performance metrics",
 	},
 	{
-		Query:       FailoverClusterAvailabilityGroupQueryAzureMI,
+		Query:       FailoverClusterReplicaStateQuery,
+		MetricName:  "sqlserver.failover_cluster.replica_state_metrics",
+		Description: "Always On Availability Group database replica state metrics",
+	},
+	{
+		Query:       FailoverClusterAvailabilityGroupHealthQuery,
+		MetricName:  "sqlserver.failover_cluster.availability_group_health_metrics",
+		Description: "Always On Availability Group health status metrics",
+	},
+	{
+		Query:       FailoverClusterAvailabilityGroupQuery,
 		MetricName:  "sqlserver.failover_cluster.availability_group_metrics",
-		Description: "Availability Group configuration metrics (Azure SQL Managed Instance)",
+		Description: "Always On Availability Group configuration metrics",
 	},
 	{
-		Query:       FailoverClusterPerformanceCounterQuery,
-		MetricName:  "sqlserver.failover_cluster.performance_counter_metrics",
-		Description: "Always On Availability Group core performance counter metrics (Azure SQL Managed Instance - simplified 3 metrics)",
-	},
-	{
-		Query:       FailoverClusterRedoQueueQueryAzureMI,
+		Query:       FailoverClusterRedoQueueQuery,
 		MetricName:  "sqlserver.failover_cluster.redo_queue_metrics",
-		Description: "Always On Availability Group redo queue metrics (Azure SQL Managed Instance only)",
+		Description: "Always On Availability Group redo queue metrics",
+	},
+	{
+		Query:       FailoverClusterRedoQueueQuery,
+		MetricName:  "sqlserver.failover_cluster.redo_queue_metrics",
+		Description: "Always On Availability Group redo queue metrics",
 	},
 }
 

--- a/receiver/newrelicsqlserverreceiver/queries/failover_cluster_metrics.go
+++ b/receiver/newrelicsqlserverreceiver/queries/failover_cluster_metrics.go
@@ -33,86 +33,30 @@
 package queries
 
 // FailoverClusterReplicaQuery returns the SQL query for Always On replica performance metrics
-// This query uses PIVOT operation to transform performance counter data into structured columns
+// This query uses GROUP BY approach to aggregate performance counter data by instance name
 // Source: sys.dm_os_performance_counters for Database Replica performance counters
 //
 // The query returns:
+// - instance_name: Database instance name from performance counters
 // - Log Bytes Received/sec: Rate of log records received by secondary replica from primary (bytes/sec)
 // - Transaction Delay: Average delay for transactions on the secondary replica (milliseconds)
 // - Flow Control Time (ms/sec): Time spent in flow control by log records (milliseconds/sec)
 const FailoverClusterReplicaQuery = `SELECT
-    [Log Bytes Received/sec],
-    [Transaction Delay],
-    [Flow Control Time (ms/sec)]
+    instance_name,
+    ISNULL(MAX(CASE WHEN counter_name = 'Log Bytes Received/sec' THEN cntr_value END), 0) AS [Log Bytes Received/sec],
+    ISNULL(MAX(CASE WHEN counter_name = 'Transaction Delay' THEN cntr_value END), 0) AS [Transaction Delay],
+    ISNULL(MAX(CASE WHEN counter_name = 'Flow Control Time (ms/sec)' THEN cntr_value END), 0) AS [Flow Control Time (ms/sec)]
 FROM
-(
-    -- Source data from Database Replica performance counters
-    SELECT
-        RTRIM(counter_name) AS counter_name,
-        cntr_value
-    FROM
-        sys.dm_os_performance_counters
-    WHERE
-        object_name LIKE '%Database Replica%'
-        AND counter_name IN (
-            'Log Bytes Received/sec',
-            'Transaction Delay',
-            'Flow Control Time (ms/sec)'
-        )
-) AS SourceData
-PIVOT
-(
-    MAX(cntr_value) -- Aggregate function for pivot operation
-    FOR counter_name IN
-    (
-        -- Transform counter names into columns
-        [Log Bytes Received/sec],
-        [Transaction Delay],
-        [Flow Control Time (ms/sec)]
+    sys.dm_os_performance_counters
+WHERE
+    object_name LIKE '%Database Replica%'
+    AND counter_name IN (
+        'Log Bytes Received/sec',
+        'Transaction Delay',
+        'Flow Control Time (ms/sec)'
     )
-) AS PivotTable;`
-
-// FailoverClusterReplicaQueryAzureSQL returns empty result for Azure SQL Database
-// Always On Availability Groups are not supported in Azure SQL Database (single database model)
-const FailoverClusterReplicaQueryAzureSQL = `SELECT 
-    CAST(NULL AS BIGINT) AS [Log Bytes Received/sec],
-    CAST(NULL AS BIGINT) AS [Transaction Delay], 
-    CAST(NULL AS BIGINT) AS [Flow Control Time (ms/sec)]
-WHERE 1=0` // Always returns empty result set
-
-// FailoverClusterReplicaQueryAzureMI returns limited query for Azure SQL Managed Instance
-// Azure SQL Managed Instance has built-in high availability but limited access to AG performance counters
-const FailoverClusterReplicaQueryAzureMI = `SELECT 
-    [Log Bytes Received/sec],
-    [Transaction Delay],
-    [Flow Control Time (ms/sec)]
-FROM
-(
-    -- Source data from Database Replica performance counters (if available)
-    SELECT
-        RTRIM(counter_name) AS counter_name,
-        cntr_value
-    FROM
-        sys.dm_os_performance_counters
-    WHERE
-        object_name LIKE '%Database Replica%'
-        AND counter_name IN (
-            'Log Bytes Received/sec',
-            'Transaction Delay', 
-            'Flow Control Time (ms/sec)'
-        )
-) AS SourceData
-PIVOT
-(
-    MAX(cntr_value) -- Aggregate function for pivot operation
-    FOR counter_name IN
-    (
-        -- Transform counter names into columns
-        [Log Bytes Received/sec],
-        [Transaction Delay],
-        [Flow Control Time (ms/sec)]
-    )
-) AS PivotTable;`
+GROUP BY
+    instance_name;`
 
 // FailoverClusterReplicaStateQuery returns the SQL query for Always On replica state metrics with extended information
 // This query joins availability replica information with database replica states to provide
@@ -157,51 +101,6 @@ JOIN
 JOIN
     sys.databases AS d ON drs.database_id = d.database_id;`
 
-// FailoverClusterReplicaStateQueryAzureSQL returns empty result for Azure SQL Database
-// Always On Availability Groups are not supported in Azure SQL Database (single database model)
-const FailoverClusterReplicaStateQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS replica_server_name,
-    CAST(NULL AS NVARCHAR(128)) AS database_name,
-    CAST(NULL AS BIGINT) AS log_send_queue_kb,
-    CAST(NULL AS BIGINT) AS redo_queue_kb,
-    CAST(NULL AS BIGINT) AS redo_rate_kb_sec,
-    CAST(NULL AS NVARCHAR(60)) AS database_state_desc,
-    CAST(NULL AS NVARCHAR(60)) AS synchronization_state_desc,
-    CAST(NULL AS BIT) AS is_local,
-    CAST(NULL AS BIT) AS is_primary_replica,
-    CAST(NULL AS VARCHAR(23)) AS last_commit_time,
-    CAST(NULL AS VARCHAR(23)) AS last_sent_time,
-    CAST(NULL AS VARCHAR(23)) AS last_received_time,
-    CAST(NULL AS VARCHAR(23)) AS last_hardened_time,
-    CAST(NULL AS VARCHAR(25)) AS last_redone_lsn,
-    CAST(NULL AS NVARCHAR(60)) AS suspend_reason_desc
-WHERE 1=0` // Always returns empty result set
-
-// FailoverClusterReplicaStateQueryAzureMI returns the extended query for Azure SQL Managed Instance
-// Azure SQL Managed Instance supports Always On AG and should have access to these DMVs
-const FailoverClusterReplicaStateQueryAzureMI = `SELECT
-    ar.replica_server_name,
-    d.name AS database_name,
-    drs.log_send_queue_size AS log_send_queue_kb,
-    drs.redo_queue_size AS redo_queue_kb,
-    drs.redo_rate AS redo_rate_kb_sec,
-    drs.database_state_desc,
-    drs.synchronization_state_desc,
-    CAST(drs.is_local AS INT) AS is_local,
-    CAST(drs.is_primary_replica AS INT) AS is_primary_replica,
-    CONVERT(VARCHAR(23), drs.last_commit_time, 121) AS last_commit_time,
-    CONVERT(VARCHAR(23), drs.last_sent_time, 121) AS last_sent_time,
-    CONVERT(VARCHAR(23), drs.last_received_time, 121) AS last_received_time,
-    CONVERT(VARCHAR(23), drs.last_hardened_time, 121) AS last_hardened_time,
-    CONVERT(VARCHAR(25), drs.last_redone_lsn) AS last_redone_lsn,
-    drs.suspend_reason_desc
-FROM
-    sys.dm_hadr_database_replica_states AS drs
-JOIN
-    sys.availability_replicas AS ar ON drs.replica_id = ar.replica_id
-JOIN
-    sys.databases AS d ON drs.database_id = d.database_id;`
-
 // FailoverClusterNodeQuery returns the SQL query for cluster node information
 // This query retrieves information about cluster nodes including their status and ownership
 //
@@ -210,22 +109,6 @@ JOIN
 // - status_description: Health state of the node (Up, Down, Paused, etc.)
 // - is_current_owner: 1 if this is the active node running SQL Server, 0 if passive
 const FailoverClusterNodeQuery = `SELECT
-    nodename,
-    status_description,
-    is_current_owner
-FROM sys.dm_os_cluster_nodes;`
-
-// FailoverClusterNodeQueryAzureSQL returns empty result for Azure SQL Database
-// Cluster nodes are not applicable in Azure SQL Database (single database model)
-const FailoverClusterNodeQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS nodename,
-    CAST(NULL AS NVARCHAR(128)) AS status_description,
-    CAST(NULL AS BIT) AS is_current_owner
-WHERE 1=0` // Always returns empty result set
-
-// FailoverClusterNodeQueryAzureMI returns the same query for Azure SQL Managed Instance
-// Azure SQL Managed Instance has built-in clustering but may have limited access to cluster node details
-const FailoverClusterNodeQueryAzureMI = `SELECT
     nodename,
     status_description,
     is_current_owner
@@ -262,22 +145,6 @@ FROM
     sys.dm_hadr_availability_replica_states AS ars
 INNER JOIN
     sys.availability_replicas AS ar ON ars.replica_id = ar.replica_id;`
-
-// FailoverClusterAvailabilityGroupHealthQueryAzureSQL returns empty result for Azure SQL Database
-// Always On Availability Groups are not supported in Azure SQL Database
-const FailoverClusterAvailabilityGroupHealthQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS replica_server_name,
-    CAST(NULL AS NVARCHAR(60)) AS role_desc,
-    CAST(NULL AS NVARCHAR(60)) AS synchronization_health_desc,
-    CAST(NULL AS NVARCHAR(60)) AS availability_mode_desc,
-    CAST(NULL AS NVARCHAR(60)) AS failover_mode_desc,
-    CAST(NULL AS INT) AS backup_priority,
-    CAST(NULL AS NVARCHAR(128)) AS endpoint_url,
-    CAST(NULL AS NVARCHAR(256)) AS read_only_routing_url,
-    CAST(NULL AS NVARCHAR(60)) AS connected_state_desc,
-    CAST(NULL AS NVARCHAR(60)) AS operational_state_desc,
-    CAST(NULL AS NVARCHAR(60)) AS recovery_health_desc
-WHERE 1=0` // Always returns empty result set
 
 // FailoverClusterAvailabilityGroupHealthQueryAzureMI returns the extended query for Azure SQL Managed Instance
 // Azure SQL Managed Instance supports Always On AG and should have access to these DMVs
@@ -318,17 +185,6 @@ const FailoverClusterAvailabilityGroupQuery = `SELECT
 FROM
     sys.availability_groups AS ag;`
 
-// FailoverClusterAvailabilityGroupQueryAzureSQL returns empty result for Azure SQL Database
-// Always On Availability Groups are not supported in Azure SQL Database
-const FailoverClusterAvailabilityGroupQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(128)) AS group_name,
-    CAST(NULL AS NVARCHAR(60)) AS automated_backup_preference_desc,
-    CAST(NULL AS INT) AS failure_condition_level,
-    CAST(NULL AS INT) AS health_check_timeout,
-    CAST(NULL AS NVARCHAR(60)) AS cluster_type_desc,
-    CAST(NULL AS INT) AS required_synchronized_secondaries_to_commit
-WHERE 1=0` // Always returns empty result set
-
 // FailoverClusterAvailabilityGroupQueryAzureMI returns the same query for Azure SQL Managed Instance
 // Azure SQL Managed Instance supports Always On AG and should have access to these DMVs
 const FailoverClusterAvailabilityGroupQueryAzureMI = `SELECT
@@ -341,175 +197,51 @@ const FailoverClusterAvailabilityGroupQueryAzureMI = `SELECT
 FROM
     sys.availability_groups AS ag;`
 
-// FailoverClusterPerformanceCounterQuery returns the SQL query for additional Always On performance counters
-// This query retrieves extended performance counters for comprehensive monitoring using PIVOT operation
-// to transform rows into columns for easier consumption in monitoring systems like New Relic
+// FailoverClusterRedoQueueQueryAzureMI returns the SQL query for Always On redo queue metrics
+// This query is specifically for Azure SQL Managed Instance and retrieves log send/redo queue information
+// for monitoring replication lag and redo performance in availability groups
+//
+// The query returns:
+// - replica_server_name: Name of the server hosting the replica
+// - database_name: Name of the database in the availability group
+// - log_send_queue_kb: Amount of log records not yet sent to secondary replica (KB)
+// - redo_queue_kb: Amount of log records waiting to be redone on secondary replica (KB)
+// - redo_rate_kb_sec: Rate at which log records are being redone on secondary replica (KB/sec)
+const FailoverClusterRedoQueueQueryAzureMI = `SELECT
+    ar.replica_server_name,
+    d.name AS database_name,
+    drs.log_send_queue_size AS log_send_queue_kb,
+    drs.redo_queue_size AS redo_queue_kb,
+    drs.redo_rate AS redo_rate_kb_sec
+FROM
+    sys.dm_hadr_database_replica_states AS drs
+JOIN
+    sys.availability_replicas AS ar ON drs.replica_id = ar.replica_id
+JOIN
+    sys.databases AS d ON drs.database_id = d.database_id;`
+
+// FailoverClusterPerformanceCounterQuery returns the SQL query for core Always On performance counters
+// This query retrieves the essential performance counters for monitoring replica performance
+// using PIVOT operation to transform rows into columns for easier consumption
 //
 // The query returns columns for each performance counter by database instance:
 // - instance_name: Database name or _Total for aggregate counters
-// - Log Send Rate (KB/sec): Rate at which log records are sent to secondary replica
-// - Recovery Queue: Number of log records waiting to be recovered
-// - File Bytes Received/sec: Rate of file bytes received per second
-// - Mirrored Write Transactions/sec: Rate of mirrored write transactions
-// - Log Bytes Flushed/sec: Rate of log bytes flushed per second
-// - Bytes Sent to Replica/sec: Rate of bytes sent to replica
-// - Bytes Received from Replica/sec: Rate of bytes received from replica
-// - Sends to Replica/sec: Rate of sends to replica
-// - Receives from Replica/sec: Rate of receives from replica
+// - Log Bytes Received/sec: Rate of log records received by secondary replica from primary (bytes/sec)
+// - Transaction Delay: Average delay for transactions on the secondary replica (milliseconds)
+// - Flow Control Time (ms/sec): Time spent in flow control by log records (milliseconds/sec)
 const FailoverClusterPerformanceCounterQuery = `SELECT
     instance_name,
-    [Log Send Rate (KB/sec)],
-    [Recovery Queue],
-    [File Bytes Received/sec],
-    [Mirrored Write Transactions/sec],
-    [Log Bytes Flushed/sec],
-    [Bytes Sent to Replica/sec],
-    [Bytes Received from Replica/sec],
-    [Sends to Replica/sec],
-    [Receives from Replica/sec]
+    ISNULL(MAX(CASE WHEN counter_name = 'Log Bytes Received/sec' THEN cntr_value END), 0) AS [Log Bytes Received/sec],
+    ISNULL(MAX(CASE WHEN counter_name = 'Transaction Delay' THEN cntr_value END), 0) AS [Transaction Delay],
+    ISNULL(MAX(CASE WHEN counter_name = 'Flow Control Time (ms/sec)' THEN cntr_value END), 0) AS [Flow Control Time (ms/sec)]
 FROM
-(
-    -- Source data from Always On performance counters
-    SELECT
-        RTRIM(instance_name) AS instance_name,
-        RTRIM(counter_name) AS counter_name,
-        cntr_value
-    FROM
-        sys.dm_os_performance_counters
-    WHERE
-        (object_name LIKE '%Database Replica%' AND counter_name IN (
-            'Log Send Rate (KB/sec)',
-            'Recovery Queue',
-            'File Bytes Received/sec',
-            'Mirrored Write Transactions/sec',
-            'Log Bytes Flushed/sec'
-        ))
-        OR (object_name LIKE '%Availability Replica%' AND counter_name IN (
-            'Bytes Sent to Replica/sec',
-            'Bytes Received from Replica/sec',
-            'Sends to Replica/sec',
-            'Receives from Replica/sec'
-        ))
-) AS SourceData
-PIVOT
-(
-    MAX(cntr_value) -- Aggregate function for pivot operation
-    FOR counter_name IN
-    (
-        -- Transform counter names into columns
-        [Log Send Rate (KB/sec)],
-        [Recovery Queue],
-        [File Bytes Received/sec],
-        [Mirrored Write Transactions/sec],
-        [Log Bytes Flushed/sec],
-        [Bytes Sent to Replica/sec],
-        [Bytes Received from Replica/sec],
-        [Sends to Replica/sec],
-        [Receives from Replica/sec]
+    sys.dm_os_performance_counters
+WHERE
+    object_name LIKE '%Database Replica%'
+    AND counter_name IN (
+        'Log Bytes Received/sec',
+        'Transaction Delay',
+        'Flow Control Time (ms/sec)'
     )
-) AS PivotTable;`
-
-// FailoverClusterPerformanceCounterQueryAzureSQL returns empty result for Azure SQL Database
-// Always On Availability Groups are not supported in Azure SQL Database
-const FailoverClusterPerformanceCounterQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(128)) AS instance_name,
-    CAST(NULL AS BIGINT) AS [Log Send Rate (KB/sec)],
-    CAST(NULL AS BIGINT) AS [Recovery Queue],
-    CAST(NULL AS BIGINT) AS [File Bytes Received/sec],
-    CAST(NULL AS BIGINT) AS [Mirrored Write Transactions/sec],
-    CAST(NULL AS BIGINT) AS [Log Bytes Flushed/sec],
-    CAST(NULL AS BIGINT) AS [Bytes Sent to Replica/sec],
-    CAST(NULL AS BIGINT) AS [Bytes Received from Replica/sec],
-    CAST(NULL AS BIGINT) AS [Sends to Replica/sec],
-    CAST(NULL AS BIGINT) AS [Receives from Replica/sec]
-WHERE 1=0` // Always returns empty result set
-
-// FailoverClusterPerformanceCounterQueryAzureMI returns the same query for Azure SQL Managed Instance
-// Azure SQL Managed Instance supports Always On AG and should have access to these performance counters
-const FailoverClusterPerformanceCounterQueryAzureMI = `SELECT
-    instance_name,
-    [Log Send Rate (KB/sec)],
-    [Recovery Queue],
-    [File Bytes Received/sec],
-    [Mirrored Write Transactions/sec],
-    [Log Bytes Flushed/sec],
-    [Bytes Sent to Replica/sec],
-    [Bytes Received from Replica/sec],
-    [Sends to Replica/sec],
-    [Receives from Replica/sec]
-FROM
-(
-    -- Source data from Always On performance counters
-    SELECT
-        RTRIM(instance_name) AS instance_name,
-        RTRIM(counter_name) AS counter_name,
-        cntr_value
-    FROM
-        sys.dm_os_performance_counters
-    WHERE
-        (object_name LIKE '%Database Replica%' AND counter_name IN (
-            'Log Send Rate (KB/sec)',
-            'Recovery Queue',
-            'File Bytes Received/sec',
-            'Mirrored Write Transactions/sec',
-            'Log Bytes Flushed/sec'
-        ))
-        OR (object_name LIKE '%Availability Replica%' AND counter_name IN (
-            'Bytes Sent to Replica/sec',
-            'Bytes Received from Replica/sec',
-            'Sends to Replica/sec',
-            'Receives from Replica/sec'
-        ))
-) AS SourceData
-PIVOT
-(
-    MAX(cntr_value) -- Aggregate function for pivot operation
-    FOR counter_name IN
-    (
-        -- Transform counter names into columns
-        [Log Send Rate (KB/sec)],
-        [Recovery Queue],
-        [File Bytes Received/sec],
-        [Mirrored Write Transactions/sec],
-        [Log Bytes Flushed/sec],
-        [Bytes Sent to Replica/sec],
-        [Bytes Received from Replica/sec],
-        [Sends to Replica/sec],
-        [Receives from Replica/sec]
-    )
-) AS PivotTable;`
-
-// FailoverClusterClusterPropertiesQuery returns the SQL query for Windows cluster properties and quorum information
-// This query retrieves cluster-level configuration and health information
-//
-// The query returns:
-// - cluster_name: Name of the Windows Server Failover Cluster
-// - quorum_type: Quorum configuration type
-// - quorum_state: Current quorum state
-const FailoverClusterClusterPropertiesQuery = `
--- Return empty result set for cluster properties since this metric is only applicable to clustered SQL Server instances
--- Most Always On AG deployments don't use traditional Windows Server Failover Clustering
-SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS cluster_name,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_type,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_state
-WHERE 1=0`
-
-// FailoverClusterClusterPropertiesQueryAzureSQL returns empty result for Azure SQL Database
-// Cluster properties are not applicable in Azure SQL Database
-const FailoverClusterClusterPropertiesQueryAzureSQL = `SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS cluster_name,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_type,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_state
-WHERE 1=0` // Always returns empty result set
-
-// FailoverClusterClusterPropertiesQueryAzureMI returns the same query for Azure SQL Managed Instance
-// Azure SQL Managed Instance has built-in clustering but may have limited access to cluster properties
-const FailoverClusterClusterPropertiesQueryAzureMI = `
--- Return empty result set for cluster properties since this metric is only applicable to clustered SQL Server instances
--- Most Always On AG deployments don't use traditional Windows Server Failover Clustering
-SELECT 
-    CAST(NULL AS NVARCHAR(256)) AS cluster_name,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_type,
-    CAST(NULL AS NVARCHAR(128)) AS quorum_state
-WHERE 1=0`
+GROUP BY
+    instance_name;`

--- a/receiver/newrelicsqlserverreceiver/scraper.go
+++ b/receiver/newrelicsqlserverreceiver/scraper.go
@@ -813,22 +813,22 @@ func (s *sqlServerScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 		s.logger.Debug("Failover cluster performance counter metrics disabled in configuration")
 	}
 
-	// Scrape cluster properties metrics if enabled
-	if s.config.IsFailoverClusterClusterPropertiesMetricsEnabled() {
-		s.logger.Debug("Starting cluster properties metrics scraping")
+	// Scrape failover cluster redo queue metrics if enabled (Azure SQL Managed Instance only)
+	if s.config.IsFailoverClusterRedoQueueMetricsEnabled() {
+		s.logger.Debug("Starting failover cluster redo queue metrics scraping")
 		scrapeCtx, cancel = context.WithTimeout(ctx, s.config.Timeout)
 		defer cancel()
-		if err := s.failoverClusterScraper.ScrapeFailoverClusterClusterPropertiesMetrics(scrapeCtx, scopeMetrics); err != nil {
-			s.logger.Error("Failed to scrape cluster properties metrics",
+		if err := s.failoverClusterScraper.ScrapeFailoverClusterRedoQueueMetrics(scrapeCtx, scopeMetrics); err != nil {
+			s.logger.Error("Failed to scrape failover cluster redo queue metrics",
 				zap.Error(err),
 				zap.Duration("timeout", s.config.Timeout))
 			scrapeErrors = append(scrapeErrors, err)
 			// Don't return here - continue with other metrics
 		} else {
-			s.logger.Debug("Successfully scraped cluster properties metrics")
+			s.logger.Debug("Successfully scraped failover cluster redo queue metrics")
 		}
 	} else {
-		s.logger.Debug("Cluster properties metrics disabled in configuration")
+		s.logger.Debug("Failover cluster redo queue metrics disabled in configuration")
 	}
 
 	// Scrape database principals metrics if enabled (using granular toggles)

--- a/receiver/newrelicsqlserverreceiver/scraper.go
+++ b/receiver/newrelicsqlserverreceiver/scraper.go
@@ -741,24 +741,6 @@ func (s *sqlServerScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 		s.logger.Debug("Failover cluster replica state metrics disabled in configuration")
 	}
 
-	// Scrape failover cluster node metrics if enabled
-	if s.config.IsFailoverClusterNodeMetricsEnabled() {
-		s.logger.Debug("Starting failover cluster node metrics scraping")
-		scrapeCtx, cancel = context.WithTimeout(ctx, s.config.Timeout)
-		defer cancel()
-		if err := s.failoverClusterScraper.ScrapeFailoverClusterNodeMetrics(scrapeCtx, scopeMetrics); err != nil {
-			s.logger.Error("Failed to scrape failover cluster node metrics",
-				zap.Error(err),
-				zap.Duration("timeout", s.config.Timeout))
-			scrapeErrors = append(scrapeErrors, err)
-			// Don't return here - continue with other metrics
-		} else {
-			s.logger.Debug("Successfully scraped failover cluster node metrics")
-		}
-	} else {
-		s.logger.Debug("Failover cluster node metrics disabled in configuration")
-	}
-
 	// Scrape availability group health metrics if enabled
 	if s.config.IsFailoverClusterAvailabilityGroupHealthMetricsEnabled() {
 		s.logger.Debug("Starting availability group health metrics scraping")
@@ -793,24 +775,6 @@ func (s *sqlServerScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 		}
 	} else {
 		s.logger.Debug("Availability group configuration metrics disabled in configuration")
-	}
-
-	// Scrape failover cluster performance counter metrics if enabled
-	if s.config.IsFailoverClusterPerformanceCounterMetricsEnabled() {
-		s.logger.Debug("Starting failover cluster performance counter metrics scraping")
-		scrapeCtx, cancel = context.WithTimeout(ctx, s.config.Timeout)
-		defer cancel()
-		if err := s.failoverClusterScraper.ScrapeFailoverClusterPerformanceCounterMetrics(scrapeCtx, scopeMetrics); err != nil {
-			s.logger.Error("Failed to scrape failover cluster performance counter metrics",
-				zap.Error(err),
-				zap.Duration("timeout", s.config.Timeout))
-			scrapeErrors = append(scrapeErrors, err)
-			// Don't return here - continue with other metrics
-		} else {
-			s.logger.Debug("Successfully scraped failover cluster performance counter metrics")
-		}
-	} else {
-		s.logger.Debug("Failover cluster performance counter metrics disabled in configuration")
 	}
 
 	// Scrape failover cluster redo queue metrics if enabled (Azure SQL Managed Instance only)

--- a/receiver/newrelicsqlserverreceiver/scrapers/scraper_failover_cluster_metrics.go
+++ b/receiver/newrelicsqlserverreceiver/scrapers/scraper_failover_cluster_metrics.go
@@ -90,6 +90,12 @@ func NewFailoverClusterScraper(conn SQLConnectionInterface, logger *zap.Logger, 
 // ScrapeFailoverClusterMetrics collects Always On Availability Group replica performance metrics
 // This method is only applicable to SQL Server deployments with Always On AG enabled
 func (s *FailoverClusterScraper) ScrapeFailoverClusterMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping failover cluster replica metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server Always On failover cluster replica metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -143,6 +149,12 @@ func (s *FailoverClusterScraper) ScrapeFailoverClusterMetrics(ctx context.Contex
 // ScrapeFailoverClusterReplicaStateMetrics collects Always On Availability Group database replica state metrics
 // This method provides detailed log synchronization metrics for each database in the availability group
 func (s *FailoverClusterScraper) ScrapeFailoverClusterReplicaStateMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping failover cluster replica state metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server Always On failover cluster replica state metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -186,9 +198,7 @@ func (s *FailoverClusterScraper) ScrapeFailoverClusterReplicaStateMetrics(ctx co
 			zap.String("database_name", result.DatabaseName),
 			zap.Int64p("log_send_queue_kb", result.LogSendQueueKB),
 			zap.Int64p("redo_queue_kb", result.RedoQueueKB),
-			zap.Int64p("redo_rate_kb_sec", result.RedoRateKBSec),
-			zap.Stringp("database_state_desc", result.DatabaseStateDesc),
-			zap.Stringp("synchronization_state_desc", result.SynchronizationStateDesc))
+			zap.Int64p("redo_rate_kb_sec", result.RedoRateKBSec))
 	}
 
 	s.logger.Debug("Successfully scraped failover cluster replica state metrics",
@@ -245,6 +255,7 @@ func (s *FailoverClusterScraper) processFailoverClusterReplicaMetrics(result mod
 		dataPoint.SetIntValue(value)
 
 		// Set attributes for failover cluster metrics
+		dataPoint.Attributes().PutStr("instance_name", result.InstanceName)
 		dataPoint.Attributes().PutStr("metric.type", sourceType)
 		dataPoint.Attributes().PutStr("metric.source", "sys.dm_os_performance_counters")
 		dataPoint.Attributes().PutStr("metric.category", "always_on_availability_group")
@@ -310,12 +321,6 @@ func (s *FailoverClusterScraper) processFailoverClusterReplicaStateMetrics(resul
 		// Set attributes for failover cluster replica state metrics
 		dataPoint.Attributes().PutStr("replica_server_name", result.ReplicaServerName)
 		dataPoint.Attributes().PutStr("database_name", result.DatabaseName)
-		if result.DatabaseStateDesc != nil {
-			dataPoint.Attributes().PutStr("database_state_desc", *result.DatabaseStateDesc)
-		}
-		if result.SynchronizationStateDesc != nil {
-			dataPoint.Attributes().PutStr("synchronization_state_desc", *result.SynchronizationStateDesc)
-		}
 		dataPoint.Attributes().PutStr("metric.type", sourceType)
 		dataPoint.Attributes().PutStr("metric.source", "sys.dm_hadr_database_replica_states")
 		dataPoint.Attributes().PutStr("metric.category", "always_on_availability_group")
@@ -329,6 +334,12 @@ func (s *FailoverClusterScraper) processFailoverClusterReplicaStateMetrics(resul
 // ScrapeFailoverClusterNodeMetrics collects cluster node information and status
 // This method retrieves information about Windows Server Failover Cluster nodes
 func (s *FailoverClusterScraper) ScrapeFailoverClusterNodeMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping failover cluster node metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server failover cluster node metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -423,6 +434,12 @@ func (s *FailoverClusterScraper) processFailoverClusterNodeMetrics(result models
 // ScrapeFailoverClusterAvailabilityGroupHealthMetrics collects Availability Group health status
 // This method retrieves health and role information for all availability group replicas
 func (s *FailoverClusterScraper) ScrapeFailoverClusterAvailabilityGroupHealthMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping Availability Group health metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server Availability Group health metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -517,6 +534,12 @@ func (s *FailoverClusterScraper) processFailoverClusterAvailabilityGroupHealthMe
 // ScrapeFailoverClusterAvailabilityGroupMetrics collects Availability Group configuration and status
 // This method retrieves detailed configuration and state information for all availability groups
 func (s *FailoverClusterScraper) ScrapeFailoverClusterAvailabilityGroupMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping Availability Group configuration metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server Availability Group configuration metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -642,6 +665,12 @@ func (s *FailoverClusterScraper) processFailoverClusterAvailabilityGroupMetrics(
 // ScrapeFailoverClusterPerformanceCounterMetrics collects Always On performance counter metrics
 // This method retrieves key performance metrics for availability group log transport
 func (s *FailoverClusterScraper) ScrapeFailoverClusterPerformanceCounterMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip failover cluster metrics for Azure SQL Database - Always On AG is not supported
+	if s.engineEdition == 5 { // Azure SQL Database
+		s.logger.Debug("Skipping Availability Group performance counter metrics - not supported in Azure SQL Database")
+		return nil
+	}
+
 	s.logger.Debug("Scraping SQL Server Availability Group performance counter metrics")
 
 	// Get the appropriate query for this engine edition using centralized query selection
@@ -687,7 +716,7 @@ func (s *FailoverClusterScraper) ScrapeFailoverClusterPerformanceCounterMetrics(
 }
 
 // processFailoverClusterPerformanceCounterMetrics processes performance counter metrics and creates OpenTelemetry metrics
-// This function handles the new PIVOT structure where each performance counter is a separate column
+// This function handles the new simplified PIVOT structure with only 3 core performance metrics
 func (s *FailoverClusterScraper) processFailoverClusterPerformanceCounterMetrics(result models.FailoverClusterPerformanceCounterMetrics, scopeMetrics pmetric.ScopeMetrics) error {
 	// Helper function to create a metric for a specific performance counter
 	createMetric := func(value *int64, metricName, unit, description, counterName string) {
@@ -713,166 +742,118 @@ func (s *FailoverClusterScraper) processFailoverClusterPerformanceCounterMetrics
 		}
 	}
 
-	// Create metrics for each performance counter column
-	createMetric(result.LogSendRateKBSec, "sqlserver.failover_cluster.log_send_rate_kb_sec", "KBy/s",
-		"Rate at which log records are sent to secondary replica in kilobytes per second", "Log Send Rate (KB/sec)")
+	// Create metrics for each of the 3 core performance counter columns
+	createMetric(result.LogBytesReceivedSec, "sqlserver.failover_cluster.log_bytes_received_per_sec", "By/s",
+		"Rate of log records received by secondary replica from primary replica in bytes per second", "Log Bytes Received/sec")
 
-	createMetric(result.RecoveryQueue, "sqlserver.failover_cluster.recovery_queue", "record",
-		"Number of log records waiting to be recovered", "Recovery Queue")
+	createMetric(result.TransactionDelay, "sqlserver.failover_cluster.transaction_delay_ms", "ms",
+		"Average delay for transactions on the secondary replica in milliseconds", "Transaction Delay")
 
-	createMetric(result.FileBytesReceivedSec, "sqlserver.failover_cluster.file_bytes_received_sec", "By/s",
-		"Rate of file bytes received per second", "File Bytes Received/sec")
-
-	createMetric(result.MirroredWriteTransactionsSec, "sqlserver.failover_cluster.mirrored_write_transactions_sec", "transaction/s",
-		"Rate of mirrored write transactions per second", "Mirrored Write Transactions/sec")
-
-	createMetric(result.LogBytesFlushedSec, "sqlserver.failover_cluster.log_bytes_flushed_sec", "By/s",
-		"Rate of log bytes flushed per second", "Log Bytes Flushed/sec")
-
-	createMetric(result.BytesSentToReplicaSec, "sqlserver.failover_cluster.bytes_sent_to_replica_sec", "By/s",
-		"Rate of bytes sent to replica per second", "Bytes Sent to Replica/sec")
-
-	createMetric(result.BytesReceivedFromReplicaSec, "sqlserver.failover_cluster.bytes_received_from_replica_sec", "By/s",
-		"Rate of bytes received from replica per second", "Bytes Received from Replica/sec")
-
-	createMetric(result.SendsToReplicaSec, "sqlserver.failover_cluster.sends_to_replica_sec", "send/s",
-		"Rate of sends to replica per second", "Sends to Replica/sec")
-
-	createMetric(result.ReceivesFromReplicaSec, "sqlserver.failover_cluster.receives_from_replica_sec", "receive/s",
-		"Rate of receives from replica per second", "Receives from Replica/sec")
+	createMetric(result.FlowControlTimeMs, "sqlserver.failover_cluster.flow_control_time_ms", "ms/s",
+		"Time spent in flow control by log records from primary replica in milliseconds per second", "Flow Control Time (ms/sec)")
 
 	return nil
 }
 
-// ScrapeFailoverClusterClusterPropertiesMetrics collects Windows Server Failover Cluster properties
-// This method retrieves cluster-wide configuration and status information
-func (s *FailoverClusterScraper) ScrapeFailoverClusterClusterPropertiesMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
-	s.logger.Debug("Scraping SQL Server cluster properties metrics")
-
-	// Get the appropriate query for this engine edition using centralized query selection
-	query, found := queries.GetQueryForMetric(queries.FailoverClusterQueries, "sqlserver.failover_cluster.cluster_properties_metrics", s.engineEdition)
-	if !found {
-		return fmt.Errorf("no cluster properties metrics query available for engine edition %d", s.engineEdition)
-	}
-
-	s.logger.Debug("Executing cluster properties metrics query",
-		zap.String("query", queries.TruncateQuery(query, 100)),
-		zap.String("engine_type", queries.GetEngineTypeName(s.engineEdition)))
-
-	var results []models.FailoverClusterClusterPropertiesMetrics
-	if err := s.connection.Query(ctx, &results, query); err != nil {
-		s.logger.Error("Failed to execute cluster properties query",
-			zap.Error(err),
-			zap.String("query", queries.TruncateQuery(query, 100)),
-			zap.Int("engine_edition", s.engineEdition))
-		return fmt.Errorf("failed to execute cluster properties query: %w", err)
-	}
-
-	// If no results, this SQL Server instance may not be part of a cluster
-	if len(results) == 0 {
-		s.logger.Debug("No cluster properties metrics found - SQL Server may not be part of a Windows Server Failover Cluster")
+// ScrapeFailoverClusterRedoQueueMetrics collects Always On redo queue metrics (Azure SQL Managed Instance only)
+// This method retrieves log send queue, redo queue, and redo rate metrics for monitoring replication performance
+func (s *FailoverClusterScraper) ScrapeFailoverClusterRedoQueueMetrics(ctx context.Context, scopeMetrics pmetric.ScopeMetrics) error {
+	// Skip for all engine types except Azure SQL Managed Instance
+	if s.engineEdition != 8 { // Azure SQL Managed Instance
+		s.logger.Debug("Skipping failover cluster redo queue metrics - only supported in Azure SQL Managed Instance",
+			zap.String("engine_type", queries.GetEngineTypeName(s.engineEdition)))
 		return nil
 	}
 
-	s.logger.Debug("Processing cluster properties metrics results",
-		zap.Int("result_count", len(results)),
+	s.logger.Debug("Scraping SQL Server Always On redo queue metrics (Azure SQL Managed Instance)")
+
+	// Get the appropriate query for this engine edition using centralized query selection
+	query, found := queries.GetQueryForMetric(queries.FailoverClusterQueries, "sqlserver.failover_cluster.redo_queue_metrics", s.engineEdition)
+	if !found {
+		return fmt.Errorf("no failover cluster redo queue metrics query available for engine edition %d", s.engineEdition)
+	}
+
+	s.logger.Debug("Executing failover cluster redo queue metrics query",
+		zap.String("query", queries.TruncateQuery(query, 100)),
 		zap.String("engine_type", queries.GetEngineTypeName(s.engineEdition)))
 
-	// Process each cluster properties result
-	for _, result := range results {
-		if err := s.processFailoverClusterClusterPropertiesMetrics(result, scopeMetrics); err != nil {
-			s.logger.Error("Failed to process cluster properties metrics",
-				zap.Error(err),
-				zap.Stringp("cluster_name", result.ClusterName))
-			return err
-		}
+	var results []models.FailoverClusterRedoQueueMetrics
+	if err := s.connection.Query(ctx, &results, query); err != nil {
+		s.logger.Error("Failed to execute failover cluster redo queue query",
+			zap.Error(err),
+			zap.String("query", queries.TruncateQuery(query, 100)),
+			zap.Int("engine_edition", s.engineEdition))
+		return fmt.Errorf("failed to execute failover cluster redo queue query: %w", err)
 	}
+
+	// If no results, this Azure SQL Managed Instance may not have Always On AG enabled or configured
+	if len(results) == 0 {
+		s.logger.Debug("No Always On redo queue metrics found - Azure SQL Managed Instance may not have Always On Availability Groups enabled")
+		return nil
+	}
+
+	s.logger.Debug("Processing failover cluster redo queue metrics results",
+		zap.Int("result_count", len(results)))
+
+	// Process each redo queue result
+	for _, result := range results {
+		if err := s.processFailoverClusterRedoQueueMetrics(result, scopeMetrics); err != nil {
+			s.logger.Error("Failed to process failover cluster redo queue metrics",
+				zap.Error(err),
+				zap.String("replica_server_name", result.ReplicaServerName),
+				zap.String("database_name", result.DatabaseName))
+			continue
+		}
+
+		s.logger.Info("Successfully scraped SQL Server Always On redo queue metrics",
+			zap.String("replica_server_name", result.ReplicaServerName),
+			zap.String("database_name", result.DatabaseName),
+			zap.Int64p("log_send_queue_kb", result.LogSendQueueKB),
+			zap.Int64p("redo_queue_kb", result.RedoQueueKB),
+			zap.Int64p("redo_rate_kb_sec", result.RedoRateKBSec))
+	}
+
+	s.logger.Debug("Successfully scraped failover cluster redo queue metrics",
+		zap.Int("result_count", len(results)))
 
 	return nil
 }
 
-// processFailoverClusterClusterPropertiesMetrics processes cluster properties metrics and creates OpenTelemetry metrics
-func (s *FailoverClusterScraper) processFailoverClusterClusterPropertiesMetrics(result models.FailoverClusterClusterPropertiesMetrics, scopeMetrics pmetric.ScopeMetrics) error {
-	// Process cluster name as an info metric
-	clusterNameMetric := scopeMetrics.Metrics().AppendEmpty()
-	clusterNameMetric.SetName("sqlserver.failover_cluster.cluster_name")
-	clusterNameMetric.SetUnit("1")
-	clusterNameMetric.SetDescription("Name of the Windows Server Failover Cluster")
+// processFailoverClusterRedoQueueMetrics processes redo queue metrics and creates OpenTelemetry metrics
+func (s *FailoverClusterScraper) processFailoverClusterRedoQueueMetrics(result models.FailoverClusterRedoQueueMetrics, scopeMetrics pmetric.ScopeMetrics) error {
+	// Helper function to create a metric for a specific redo queue counter
+	createMetric := func(value *int64, metricName, unit, description string) {
+		if value != nil {
+			metric := scopeMetrics.Metrics().AppendEmpty()
+			metric.SetName(metricName)
+			metric.SetUnit(unit)
+			metric.SetDescription(description)
 
-	clusterNameGauge := clusterNameMetric.SetEmptyGauge()
-	clusterNameDataPoint := clusterNameGauge.DataPoints().AppendEmpty()
-	clusterNameDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-	clusterNameDataPoint.SetStartTimestamp(s.startTime)
-	clusterNameDataPoint.SetIntValue(1) // Info metric always has value 1
+			gauge := metric.SetEmptyGauge()
+			dataPoint := gauge.DataPoints().AppendEmpty()
+			dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dataPoint.SetStartTimestamp(s.startTime)
+			dataPoint.SetIntValue(*value)
 
-	// Add attributes for cluster name metric
-	if result.ClusterName != nil {
-		clusterNameDataPoint.Attributes().PutStr("cluster_name", *result.ClusterName)
-	}
-	if result.QuorumType != nil {
-		clusterNameDataPoint.Attributes().PutStr("quorum_type", *result.QuorumType)
-	}
-	if result.QuorumState != nil {
-		clusterNameDataPoint.Attributes().PutStr("quorum_state", *result.QuorumState)
-	}
-	clusterNameDataPoint.Attributes().PutStr("metric.source", "sys.dm_hadr_cluster")
-	clusterNameDataPoint.Attributes().PutStr("metric.category", "cluster_properties")
-	clusterNameDataPoint.Attributes().PutStr("engine_edition", queries.GetEngineTypeName(s.engineEdition))
-	clusterNameDataPoint.Attributes().PutInt("engine_edition_id", int64(s.engineEdition))
-
-	// Process quorum type as an info metric
-	if result.QuorumType != nil {
-		quorumTypeMetric := scopeMetrics.Metrics().AppendEmpty()
-		quorumTypeMetric.SetName("sqlserver.failover_cluster.quorum_type")
-		quorumTypeMetric.SetUnit("1")
-		quorumTypeMetric.SetDescription("Type of quorum configuration for the cluster")
-
-		quorumTypeGauge := quorumTypeMetric.SetEmptyGauge()
-		quorumTypeDataPoint := quorumTypeGauge.DataPoints().AppendEmpty()
-		quorumTypeDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		quorumTypeDataPoint.SetStartTimestamp(s.startTime)
-		quorumTypeDataPoint.SetIntValue(1) // Info metric always has value 1
-
-		// Add attributes for quorum type metric
-		if result.ClusterName != nil {
-			quorumTypeDataPoint.Attributes().PutStr("cluster_name", *result.ClusterName)
+			// Add attributes
+			dataPoint.Attributes().PutStr("replica_server_name", result.ReplicaServerName)
+			dataPoint.Attributes().PutStr("database_name", result.DatabaseName)
+			dataPoint.Attributes().PutStr("metric.source", "sys.dm_hadr_database_replica_states")
+			dataPoint.Attributes().PutStr("metric.category", "always_on_redo_queue")
+			dataPoint.Attributes().PutStr("engine_edition", queries.GetEngineTypeName(s.engineEdition))
+			dataPoint.Attributes().PutInt("engine_edition_id", int64(s.engineEdition))
 		}
-		quorumTypeDataPoint.Attributes().PutStr("quorum_type", *result.QuorumType)
-		if result.QuorumState != nil {
-			quorumTypeDataPoint.Attributes().PutStr("quorum_state", *result.QuorumState)
-		}
-		quorumTypeDataPoint.Attributes().PutStr("metric.source", "sys.dm_hadr_cluster")
-		quorumTypeDataPoint.Attributes().PutStr("metric.category", "cluster_properties")
-		quorumTypeDataPoint.Attributes().PutStr("engine_edition", queries.GetEngineTypeName(s.engineEdition))
-		quorumTypeDataPoint.Attributes().PutInt("engine_edition_id", int64(s.engineEdition))
 	}
 
-	// Process quorum state as an info metric
-	if result.QuorumState != nil {
-		quorumStateMetric := scopeMetrics.Metrics().AppendEmpty()
-		quorumStateMetric.SetName("sqlserver.failover_cluster.quorum_state")
-		quorumStateMetric.SetUnit("1")
-		quorumStateMetric.SetDescription("Current state of the cluster quorum")
+	// Create metrics for each of the 3 redo queue columns
+	createMetric(result.LogSendQueueKB, "sqlserver.failover_cluster.log_send_queue_kb", "KBy",
+		"Amount of log records not yet sent to secondary replica in kilobytes")
 
-		quorumStateGauge := quorumStateMetric.SetEmptyGauge()
-		quorumStateDataPoint := quorumStateGauge.DataPoints().AppendEmpty()
-		quorumStateDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		quorumStateDataPoint.SetStartTimestamp(s.startTime)
-		quorumStateDataPoint.SetIntValue(1) // Info metric always has value 1
+	createMetric(result.RedoQueueKB, "sqlserver.failover_cluster.redo_queue_kb", "KBy",
+		"Amount of log records waiting to be redone on secondary replica in kilobytes")
 
-		// Add attributes for quorum state metric
-		if result.ClusterName != nil {
-			quorumStateDataPoint.Attributes().PutStr("cluster_name", *result.ClusterName)
-		}
-		if result.QuorumType != nil {
-			quorumStateDataPoint.Attributes().PutStr("quorum_type", *result.QuorumType)
-		}
-		quorumStateDataPoint.Attributes().PutStr("quorum_state", *result.QuorumState)
-		quorumStateDataPoint.Attributes().PutStr("metric.source", "sys.dm_hadr_cluster")
-		quorumStateDataPoint.Attributes().PutStr("metric.category", "cluster_properties")
-		quorumStateDataPoint.Attributes().PutStr("engine_edition", queries.GetEngineTypeName(s.engineEdition))
-		quorumStateDataPoint.Attributes().PutInt("engine_edition_id", int64(s.engineEdition))
-	}
+	createMetric(result.RedoRateKBSec, "sqlserver.failover_cluster.redo_rate_kb_sec", "KBy/s",
+		"Rate at which log records are being redone on secondary replica in kilobytes per second")
 
 	return nil
 }
@@ -905,12 +886,6 @@ func (s *FailoverClusterScraper) getMetricUnit(metricName string) string {
 	case "sqlserver.failover_cluster.ag_health_check_timeout":
 		return "ms"
 	case "sqlserver.failover_cluster.ag_cluster_type":
-		return "1"
-	case "sqlserver.failover_cluster.cluster_name":
-		return "1"
-	case "sqlserver.failover_cluster.quorum_type":
-		return "1"
-	case "sqlserver.failover_cluster.quorum_state":
 		return "1"
 	default:
 		return "1"
@@ -946,12 +921,6 @@ func (s *FailoverClusterScraper) getMetricDescription(metricName string) string 
 		return "Health check timeout for the availability group in milliseconds"
 	case "sqlserver.failover_cluster.ag_cluster_type":
 		return "Cluster type for the availability group (WSFC, EXTERNAL, NONE)"
-	case "sqlserver.failover_cluster.cluster_name":
-		return "Name of the Windows Server Failover Cluster"
-	case "sqlserver.failover_cluster.quorum_type":
-		return "Type of quorum configuration for the cluster"
-	case "sqlserver.failover_cluster.quorum_state":
-		return "Current state of the cluster quorum"
 	default:
 		return fmt.Sprintf("SQL Server Always On failover cluster %s metric", metricName)
 	}

--- a/receiver/newrelicsqlserverreceiver/scrapers/scraper_failover_cluster_metrics_test.go
+++ b/receiver/newrelicsqlserverreceiver/scrapers/scraper_failover_cluster_metrics_test.go
@@ -505,12 +505,6 @@ func TestFailoverClusterScraper_AzureSQLDatabaseSkipping(t *testing.T) {
 
 	// Reset scope metrics for next test
 	scopeMetrics = pmetric.NewScopeMetrics()
-	err = scraper.ScrapeFailoverClusterNodeMetrics(ctx, scopeMetrics)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, scopeMetrics.Metrics().Len(), "Azure SQL Database should not create any node metrics")
-
-	// Reset scope metrics for next test
-	scopeMetrics = pmetric.NewScopeMetrics()
 	err = scraper.ScrapeFailoverClusterAvailabilityGroupHealthMetrics(ctx, scopeMetrics)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, scopeMetrics.Metrics().Len(), "Azure SQL Database should not create any AG health metrics")
@@ -523,13 +517,7 @@ func TestFailoverClusterScraper_AzureSQLDatabaseSkipping(t *testing.T) {
 
 	// Reset scope metrics for next test
 	scopeMetrics = pmetric.NewScopeMetrics()
-	err = scraper.ScrapeFailoverClusterPerformanceCounterMetrics(ctx, scopeMetrics)
+	err = scraper.ScrapeFailoverClusterRedoQueueMetrics(ctx, scopeMetrics)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, scopeMetrics.Metrics().Len(), "Azure SQL Database should not create any performance counter metrics")
-
-	// Reset scope metrics for next test
-	scopeMetrics = pmetric.NewScopeMetrics()
-	err = scraper.ScrapeFailoverClusterPerformanceCounterMetrics(ctx, scopeMetrics)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, scopeMetrics.Metrics().Len(), "Azure SQL Database should not create any performance counter metrics")
+	assert.Equal(t, 0, scopeMetrics.Metrics().Len(), "Azure SQL Database should not create any redo queue metrics")
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added MSSQL Failover cluster metrics for Azure Managed Instance and updated the failover queries for both databases. Since the queries are identical for both Standard SQL and Azure SQL Managed Instance, I modified and updated the queries, models, scrapers, and toggles accordingly.

